### PR TITLE
Revamp explorer layout and UX

### DIFF
--- a/颱風/assets/css/styles.css
+++ b/颱風/assets/css/styles.css
@@ -13,7 +13,25 @@
   --radius-lg: 22px;
   --radius-md: 16px;
   --radius-sm: 12px;
-  --sidebar-w: 440px;
+  --sidebar-w: 380px;
+}
+
+body[data-theme="mono"] {
+  --bg: radial-gradient(circle at top, #1c1d22 0%, #0d0d10 55%, #080809 100%);
+  --panel: rgba(24, 26, 32, 0.9);
+  --panel-solid: #1c1d22;
+  --border: rgba(180, 180, 180, 0.22);
+  --border-strong: rgba(200, 200, 200, 0.42);
+  --accent: #f0f0f0;
+  --accent-strong: #cfcfcf;
+  --accent-soft: rgba(210, 210, 210, 0.18);
+  --text: #f6f6f6;
+  --muted: #b0b0b0;
+  --heading: #ffffff;
+}
+
+body[data-theme="mono"] .map-container {
+  filter: grayscale(0.85) contrast(1.08);
 }
 
 * {
@@ -42,6 +60,18 @@ a:hover {
   color: #9cc0ff;
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 kbd {
   display: inline-block;
   padding: 2px 6px;
@@ -56,7 +86,7 @@ kbd {
 }
 
 .shell {
-  width: min(1180px, 90vw);
+  width: min(1380px, 96vw);
   margin: 0 auto;
   display: flex;
   align-items: center;
@@ -125,7 +155,7 @@ kbd {
 }
 
 .explorer-main {
-  width: min(1180px, 92vw);
+  width: min(1380px, 96vw);
   margin: 0 auto;
   padding: 40px 0 64px;
   display: flex;
@@ -216,10 +246,52 @@ kbd {
   border-radius: 14px;
 }
 
+
+.panel-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.panel-toggle {
+  border: 1px solid var(--border);
+  background: rgba(122, 163, 255, 0.08);
+  color: var(--heading);
+  border-radius: 999px;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.panel-toggle::after {
+  content: '⌄';
+  font-size: 14px;
+  transform: rotate(0deg);
+  transition: transform 0.2s ease;
+}
+
+.panel-toggle:hover {
+  background: rgba(122, 163, 255, 0.2);
+}
+
+.panel.collapsed .panel-toggle::after {
+  transform: rotate(-90deg);
+}
+
+.panel-body[hidden] {
+  display: none;
+}
+
 .app-grid {
   display: grid;
-  grid-template-columns: var(--sidebar-w) 1fr;
-  gap: 28px;
+  grid-template-columns: minmax(0, var(--sidebar-w)) minmax(0, 1fr);
+  gap: 32px;
   min-height: 70vh;
   transition: grid-template-columns 0.3s ease, gap 0.3s ease;
 }
@@ -235,7 +307,7 @@ kbd {
 }
 
 #app.collapsed {
-  grid-template-columns: minmax(0, 1fr);
+  grid-template-columns: 0 minmax(0, 1fr);
   gap: 0;
 }
 
@@ -245,10 +317,6 @@ kbd {
   transform: translateX(-24px);
   max-width: 0;
   margin: 0;
-}
-
-#app.collapsed .map-area {
-  width: 100%;
 }
 
 .panel-group {
@@ -303,6 +371,7 @@ kbd {
 .shortcut-list li {
   line-height: 1.5;
 }
+
 
 .note {
   font-size: 12px;
@@ -517,24 +586,32 @@ kbd {
   white-space: pre-wrap;
 }
 
-#tsWrap {
-  height: 280px;
+.workspace {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
 }
 
-.map-area {
-  display: flex;
-  position: relative;
+.workspace-main {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(320px, 28%);
+  gap: 28px;
+  align-items: start;
+}
+
+.map-card {
+  background: rgba(10, 16, 32, 0.82);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  box-shadow: 0 20px 48px rgba(5, 10, 26, 0.55);
+  overflow: hidden;
 }
 
 .map-container {
   position: relative;
   width: 100%;
   background: rgba(8, 12, 24, 0.8);
-  border-radius: var(--radius-lg);
-  border: 1px solid var(--border);
-  overflow: hidden;
-  min-height: 640px;
-  box-shadow: 0 20px 48px rgba(5, 10, 26, 0.55);
+  min-height: 580px;
 }
 
 #map {
@@ -542,6 +619,321 @@ kbd {
   width: 100%;
 }
 
+.detail-panel {
+  background: rgba(10, 16, 32, 0.9);
+  border: 1px solid rgba(126, 146, 255, 0.32);
+  border-radius: var(--radius-lg);
+  padding: 22px 22px 26px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  box-shadow: 0 18px 42px rgba(6, 12, 28, 0.45);
+}
+
+.detail-panel.hidden {
+  display: none;
+}
+
+.detail-panel.empty .detail-hero,
+.detail-panel.empty .detail-meta-grid,
+.detail-panel.empty .detail-timeline {
+  opacity: 0.6;
+}
+
+.detail-panel.empty .detail-badges {
+  opacity: 0.7;
+}
+
+.detail-panel.empty .detail-controls .icon-btn:not(#detailClose) {
+  pointer-events: none;
+  opacity: 0.35;
+}
+
+.detail-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.detail-header h3 {
+  margin: 0;
+  font-size: 18px;
+  color: var(--heading);
+}
+
+.detail-header p {
+  margin: 4px 0 0;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.detail-controls {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.icon-btn {
+  border: none;
+  background: rgba(122, 163, 255, 0.16);
+  color: var(--heading);
+  border-radius: 999px;
+  width: 32px;
+  height: 32px;
+  cursor: pointer;
+  font-size: 18px;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.icon-btn:hover:not(:disabled) {
+  background: rgba(122, 163, 255, 0.32);
+  transform: translateY(-1px);
+}
+
+.icon-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.detail-hero {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.detail-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: rgba(122, 163, 255, 0.16);
+  border: 1px solid rgba(122, 163, 255, 0.32);
+  border-radius: 999px;
+  padding: 6px 12px;
+  font-size: 12px;
+  color: var(--heading);
+  font-weight: 600;
+}
+
+.badge.system::before {
+  content: '🌀';
+}
+
+.badge.member::before {
+  content: '👥';
+}
+
+.detail-wind {
+  margin-top: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.metric-value {
+  font-size: 22px;
+  font-weight: 800;
+  color: var(--heading);
+}
+
+.metric-sub {
+  font-size: 12px;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.detail-grades {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  align-items: flex-end;
+}
+
+.grade {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 14px;
+  border-radius: 12px;
+  background: rgba(122, 163, 255, 0.18);
+  border: 1px solid rgba(122, 163, 255, 0.32);
+  color: var(--heading);
+  font-weight: 700;
+  font-size: 13px;
+}
+
+.grade.alt {
+  background: rgba(102, 210, 255, 0.18);
+  border-color: rgba(102, 210, 255, 0.32);
+}
+
+.detail-meta-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.meta-item {
+  background: rgba(12, 18, 36, 0.82);
+  border: 1px solid rgba(122, 163, 255, 0.14);
+  border-radius: var(--radius-sm);
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.meta-label {
+  font-size: 11px;
+  letter-spacing: 1px;
+  color: var(--muted);
+  text-transform: uppercase;
+}
+
+.meta-value {
+  font-size: 14px;
+  color: var(--heading);
+  font-weight: 600;
+  word-break: break-word;
+}
+
+.detail-timeline {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.timeline-card {
+  background: rgba(12, 18, 36, 0.8);
+  border: 1px solid rgba(122, 163, 255, 0.18);
+  border-radius: var(--radius-sm);
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--muted);
+  min-height: 118px;
+}
+
+.timeline-card.current {
+  border-color: rgba(122, 163, 255, 0.36);
+  background: rgba(122, 163, 255, 0.12);
+  color: var(--heading);
+}
+
+.timeline-card.inactive {
+  opacity: 0.6;
+}
+
+.timeline-title {
+  font-weight: 700;
+  font-size: 13px;
+}
+
+.timeline-time,
+.timeline-wind,
+.timeline-trend {
+  font-size: 12px;
+}
+
+.detail-footer {
+  margin-top: 4px;
+  font-size: 12px;
+  line-height: 1.6;
+  color: var(--muted);
+  background: rgba(12, 18, 36, 0.7);
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(122, 163, 255, 0.12);
+  padding: 12px 14px;
+}
+
+.analysis-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 24px;
+}
+
+.analysis-card {
+  background: rgba(10, 16, 32, 0.82);
+  border: 1px solid rgba(126, 146, 255, 0.18);
+  border-radius: var(--radius-lg);
+  padding: 22px 24px;
+  box-shadow: 0 16px 32px rgba(5, 10, 26, 0.4);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.analysis-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+
+.analysis-header h2 {
+  margin: 0;
+  font-size: 20px;
+  color: var(--heading);
+}
+
+.analysis-sub {
+  margin: 6px 0 0;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+#tsWrap {
+  height: 320px;
+}
+
+.ts-inspector {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
+  background: rgba(12, 18, 36, 0.8);
+  border: 1px solid rgba(122, 163, 255, 0.2);
+  border-radius: var(--radius-sm);
+  padding: 12px 16px;
+  font-size: 13px;
+  color: var(--heading);
+}
+
+.ts-inspector-main {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.ts-time {
+  font-weight: 600;
+}
+
+.ts-value {
+  font-size: 16px;
+  font-weight: 700;
+}
+
+.ts-inspector-meta {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  color: var(--muted);
+}
+
+.ts-grade {
+  font-weight: 600;
+}
 .legend {
   position: absolute;
   left: 24px;
@@ -621,191 +1013,6 @@ kbd {
   z-index: 1200;
 }
 
-.detail-drawer {
-  position: absolute;
-  top: 24px;
-  right: 24px;
-  width: min(340px, 85vw);
-  background: rgba(12, 20, 38, 0.95);
-  border: 1px solid rgba(126, 146, 255, 0.32);
-  border-radius: var(--radius-lg);
-  box-shadow: 0 24px 48px rgba(5, 10, 24, 0.6);
-  padding: 22px 22px 26px;
-  display: flex;
-  flex-direction: column;
-  gap: 18px;
-  z-index: 950;
-  transition: opacity 0.3s ease, transform 0.3s ease;
-}
-
-.detail-drawer.hidden {
-  opacity: 0;
-  pointer-events: none;
-  transform: translateY(-12px);
-}
-
-.drawer-header {
-  display: flex;
-  justify-content: space-between;
-  gap: 16px;
-}
-
-.drawer-header h3 {
-  margin: 0;
-  font-size: 18px;
-  color: var(--heading);
-}
-
-.drawer-header p {
-  margin: 4px 0 0;
-  font-size: 13px;
-  color: var(--muted);
-}
-
-.icon-btn {
-  border: none;
-  background: rgba(122, 163, 255, 0.16);
-  color: var(--heading);
-  border-radius: 999px;
-  width: 32px;
-  height: 32px;
-  cursor: pointer;
-  font-size: 18px;
-}
-
-.icon-btn:hover {
-  background: rgba(122, 163, 255, 0.32);
-}
-
-.drawer-controls {
-  display: flex;
-  gap: 8px;
-  align-items: center;
-}
-
-.detail-meta-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px;
-}
-
-.meta-item {
-  background: rgba(12, 18, 36, 0.82);
-  border: 1px solid rgba(122, 163, 255, 0.14);
-  border-radius: var(--radius-sm);
-  padding: 10px 12px;
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.meta-label {
-  font-size: 11px;
-  text-transform: uppercase;
-  letter-spacing: 1px;
-  color: var(--muted);
-}
-
-.meta-value {
-  font-size: 14px;
-  color: var(--heading);
-  font-weight: 600;
-  word-break: break-word;
-}
-
-.detail-metrics {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  gap: 12px;
-}
-
-.metric-card {
-  background: rgba(122, 163, 255, 0.08);
-  border: 1px solid rgba(122, 163, 255, 0.18);
-  border-radius: var(--radius-sm);
-  padding: 12px;
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.metric-label {
-  font-size: 11px;
-  letter-spacing: 0.5px;
-  color: var(--muted);
-  text-transform: uppercase;
-}
-
-.metric-value {
-  font-size: 18px;
-  font-weight: 700;
-  color: var(--heading);
-}
-
-.metric-sub {
-  font-size: 12px;
-  color: var(--muted);
-  line-height: 1.5;
-}
-
-.detail-timeline {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 12px;
-}
-
-.timeline-card {
-  background: rgba(12, 18, 36, 0.9);
-  border: 1px solid rgba(122, 163, 255, 0.18);
-  border-radius: var(--radius-sm);
-  padding: 12px;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  min-height: 120px;
-}
-
-.timeline-card.current {
-  border-color: rgba(122, 163, 255, 0.45);
-  background: rgba(122, 163, 255, 0.14);
-}
-
-.timeline-card.inactive {
-  opacity: 0.45;
-}
-
-.timeline-title {
-  font-size: 11px;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  color: var(--muted);
-}
-
-.timeline-time {
-  font-size: 13px;
-  color: var(--heading);
-  font-weight: 600;
-}
-
-.timeline-wind {
-  font-size: 12px;
-  color: var(--muted);
-}
-
-.timeline-trend {
-  font-size: 12px;
-  color: var(--heading);
-  font-weight: 600;
-}
-
-.drawer-footer {
-  font-size: 12px;
-  line-height: 1.6;
-  color: var(--muted);
-  background: rgba(122, 163, 255, 0.08);
-  border-radius: var(--radius-sm);
-  padding: 12px;
-}
 
 .site-footer {
   margin-top: auto;
@@ -859,8 +1066,9 @@ kbd {
 
 @media (max-width: 1100px) {
   :root { --sidebar-w: 360px; }
-  .app-grid { gap: 18px; }
-  .map-container { min-height: 600px; }
+  .app-grid { gap: 24px; }
+  .workspace-main { grid-template-columns: minmax(0, 1fr) minmax(280px, 32%); }
+  .map-container { min-height: 520px; }
 }
 
 @media (max-width: 960px) {
@@ -877,15 +1085,19 @@ kbd {
   #app.collapsed #sidebar {
     display: none;
   }
+  .workspace-main {
+    grid-template-columns: 1fr;
+  }
+  .detail-panel {
+    position: static;
+  }
+  .analysis-grid {
+    grid-template-columns: 1fr;
+  }
   .legend {
     left: 18px;
     right: 18px;
     max-width: calc(100% - 36px);
-  }
-  .detail-drawer {
-    position: static;
-    width: 100%;
-    margin: 20px auto 0;
   }
   .detail-meta-grid {
     grid-template-columns: 1fr;
@@ -912,6 +1124,9 @@ kbd {
   }
   .explorer-main {
     width: 92vw;
+  }
+  .map-container {
+    min-height: 460px;
   }
   .legend .tools {
     width: 100%;

--- a/颱風/explorer.html
+++ b/颱風/explorer.html
@@ -38,18 +38,24 @@
       <div class="intro-actions">
         <button class="btn" id="btnCollapse">隱藏資料面板</button>
         <button class="btn outline" id="btnShareTop">分享目前視圖</button>
+        <button class="btn ghost" id="btnThemeToggle" aria-pressed="false">切換黑白模式</button>
       </div>
     </section>
 
     <div id="app" class="app-grid">
       <aside id="sidebar" aria-label="資料操作面板">
         <div class="panel-group">
-          <section class="panel">
-            <header>
-              <div class="panel-title">線上資料</div>
-              <p class="panel-sub">DeepMind WeatherLab</p>
+          <section class="panel" data-panel-id="online">
+            <header class="panel-header">
+              <div>
+                <div class="panel-title">線上資料</div>
+                <p class="panel-sub">DeepMind WeatherLab</p>
+              </div>
+              <button class="panel-toggle" type="button" aria-expanded="true" aria-controls="panel-online-body">
+                <span class="sr-only">切換「線上資料」區塊</span>
+              </button>
             </header>
-            <div class="panel-body">
+            <div class="panel-body" id="panel-online-body">
               <div class="field-grid">
                 <label for="dmModel">模型</label>
                 <select id="dmModel">
@@ -70,12 +76,17 @@
             </div>
           </section>
 
-          <section class="panel">
-            <header>
-              <div class="panel-title">匯入資料</div>
-              <p class="panel-sub">支援多個 CSV</p>
+          <section class="panel" data-panel-id="import">
+            <header class="panel-header">
+              <div>
+                <div class="panel-title">匯入資料</div>
+                <p class="panel-sub">支援多個 CSV</p>
+              </div>
+              <button class="panel-toggle" type="button" aria-expanded="true" aria-controls="panel-import-body">
+                <span class="sr-only">切換「匯入資料」區塊</span>
+              </button>
             </header>
-            <div class="panel-body">
+            <div class="panel-body" id="panel-import-body">
               <label class="upload" id="fileLabel">
                 <input type="file" id="csvFiles" accept=".csv" multiple/>
                 <span>📄 點我匯入多個 CSV</span>
@@ -83,12 +94,17 @@
             </div>
           </section>
 
-          <section class="panel">
-            <header>
-              <div class="panel-title">視圖模式</div>
-              <p class="panel-sub">選擇路線或機率熱度</p>
+          <section class="panel" data-panel-id="view-mode">
+            <header class="panel-header">
+              <div>
+                <div class="panel-title">視圖模式</div>
+                <p class="panel-sub">選擇路線或機率熱度</p>
+              </div>
+              <button class="panel-toggle" type="button" aria-expanded="true" aria-controls="panel-view-body">
+                <span class="sr-only">切換「視圖模式」區塊</span>
+              </button>
             </header>
-            <div class="panel-body">
+            <div class="panel-body" id="panel-view-body">
               <div class="chip-row">
                 <span class="chip" id="modeTracks" data-active="true">路線圖</span>
                 <span class="chip" id="modeProb">機率圖</span>
@@ -97,11 +113,14 @@
             </div>
           </section>
 
-          <section class="panel">
-            <header>
+          <section class="panel" data-panel-id="det-color">
+            <header class="panel-header">
               <div class="panel-title">決定性顏色</div>
+              <button class="panel-toggle" type="button" aria-expanded="true" aria-controls="panel-det-body">
+                <span class="sr-only">切換「決定性顏色」區塊</span>
+              </button>
             </header>
-            <div class="panel-body">
+            <div class="panel-body" id="panel-det-body">
               <div class="chip-row">
                 <span class="chip" id="detBlack" data-active="true">黑線</span>
                 <span class="chip" id="detIntensity">強度上色</span>
@@ -109,11 +128,14 @@
             </div>
           </section>
 
-          <section class="panel">
-            <header>
+          <section class="panel" data-panel-id="visibility">
+            <header class="panel-header">
               <div class="panel-title">顯示選項</div>
+              <button class="panel-toggle" type="button" aria-expanded="true" aria-controls="panel-visibility-body">
+                <span class="sr-only">切換「顯示選項」區塊</span>
+              </button>
             </header>
-            <div class="panel-body">
+            <div class="panel-body" id="panel-visibility-body">
               <div class="toggle-grid">
                 <label class="toggle"><input type="checkbox" id="toggleDet" checked><span>決定性</span></label>
                 <label class="toggle"><input type="checkbox" id="toggleEns" checked><span>系集</span></label>
@@ -123,11 +145,14 @@
             </div>
           </section>
 
-          <section class="panel">
-            <header>
+          <section class="panel" data-panel-id="converter">
+            <header class="panel-header">
               <div class="panel-title">風速換算</div>
+              <button class="panel-toggle" type="button" aria-expanded="true" aria-controls="panel-converter-body">
+                <span class="sr-only">切換「風速換算」區塊</span>
+              </button>
             </header>
-            <div class="panel-body">
+            <div class="panel-body" id="panel-converter-body">
               <div class="field-grid compact">
                 <input type="number" id="wsValue" placeholder="數值" step="0.01"/>
                 <select id="wsUnit">
@@ -141,48 +166,46 @@
             </div>
           </section>
 
-          <section class="panel">
-            <header>
-              <div class="panel-title">系統清單</div>
-              <p class="panel-sub">track_id | 檔名</p>
+          <section class="panel" data-panel-id="systems">
+            <header class="panel-header">
+              <div>
+                <div class="panel-title">系統清單</div>
+                <p class="panel-sub">track_id | 檔名</p>
+              </div>
+              <button class="panel-toggle" type="button" aria-expanded="true" aria-controls="panel-systems-body">
+                <span class="sr-only">切換「系統清單」區塊</span>
+              </button>
             </header>
-            <div class="panel-body">
+            <div class="panel-body" id="panel-systems-body">
               <input class="search" id="systemFilter" type="search" placeholder="搜尋系統或檔案"/>
               <div class="status muted" id="systemSummary">尚無資料</div>
               <div id="systems" class="sys-list"></div>
             </div>
           </section>
 
-          <section class="panel">
-            <header>
-              <div class="panel-title">時間 × 強度圖</div>
-            </header>
-            <div class="panel-body">
-              <div class="chip-row dense">
-                <select id="tsSystemSel"></select>
-                <span class="chip" id="tsModeDet" data-active="true">決定性</span>
-                <span class="chip" id="tsModeEns">所有系集</span>
-              </div>
-              <div id="tsWrap"><canvas id="tsChart"></canvas></div>
-              <p class="note">滑鼠移入圖表，可檢視節點詳細資訊與分級。</p>
-            </div>
-          </section>
-
-          <section class="panel">
-            <header>
+          <section class="panel" data-panel-id="history">
+            <header class="panel-header">
               <div class="panel-title">歷史操作與診斷</div>
+              <button class="panel-toggle" type="button" aria-expanded="true" aria-controls="panel-history-body">
+                <span class="sr-only">切換「歷史操作與診斷」區塊</span>
+              </button>
             </header>
-            <div class="panel-body">
+            <div class="panel-body" id="panel-history-body">
               <div id="historyLog" class="history"></div>
             </div>
           </section>
 
-          <section class="panel">
-            <header>
-              <div class="panel-title">鍵盤快捷鍵</div>
-              <p class="panel-sub">桌面版最佳化操作</p>
+          <section class="panel" data-panel-id="shortcuts">
+            <header class="panel-header">
+              <div>
+                <div class="panel-title">鍵盤快捷鍵</div>
+                <p class="panel-sub">桌面版最佳化操作</p>
+              </div>
+              <button class="panel-toggle" type="button" aria-expanded="false" aria-controls="panel-shortcuts-body">
+                <span class="sr-only">切換「鍵盤快捷鍵」區塊</span>
+              </button>
             </header>
-            <div class="panel-body">
+            <div class="panel-body" id="panel-shortcuts-body" hidden>
               <ul class="shortcut-list">
                 <li><kbd>Shift</kbd> + <kbd>C</kbd>：收合／展開資料面板</li>
                 <li><kbd>Shift</kbd> + <kbd>L</kbd>：載入最新可用循環</li>
@@ -196,78 +219,104 @@
           </section>
         </div>
       </aside>
-
-      <section class="map-area">
-        <div class="map-container">
-          <div id="map"></div>
-          <div class="legend" id="legend" aria-live="polite">
-            <div class="legend-scale">
-              <div class="scale-bar" id="legendGradient"></div>
-              <div class="scale-labels" id="legendStops"></div>
-            </div>
-            <div class="legend-list" id="legendText"></div>
-            <div class="tools">
-              <button class="btn ghost" id="unitToggle" title="切換單位">單位：kt</button>
-              <button class="btn ghost" id="btnShare" title="產生可分享連結">分享此視圖</button>
+      <section class="workspace">
+        <div class="workspace-main">
+          <div class="map-card">
+            <div class="map-container">
+              <div id="map"></div>
+              <div class="legend" id="legend" aria-live="polite">
+                <div class="legend-scale">
+                  <div class="scale-bar" id="legendGradient"></div>
+                  <div class="scale-labels" id="legendStops"></div>
+                </div>
+                <div class="legend-list" id="legendText"></div>
+                <div class="tools">
+                  <button class="btn ghost" id="unitToggle" title="切換單位">單位：kt</button>
+                  <button class="btn ghost" id="btnShare" title="產生可分享連結">分享此視圖</button>
+                </div>
+              </div>
             </div>
           </div>
-          <aside class="detail-drawer" id="detailPanel">
-            <div class="drawer-header">
+          <aside class="detail-panel" id="detailPanel">
+            <div class="detail-header">
               <div>
                 <h3 id="detailTitle">點選節點以檢視詳細資料</h3>
                 <p id="detailSubtitle">同時支援決定性與系集成員。</p>
               </div>
-              <div class="drawer-controls">
+              <div class="detail-controls">
                 <button class="icon-btn" id="detailPrevBtn" aria-label="上一節點" disabled>←</button>
                 <button class="icon-btn" id="detailNextBtn" aria-label="下一節點" disabled>→</button>
                 <button class="icon-btn" id="detailClose" aria-label="關閉詳細資訊">×</button>
               </div>
             </div>
-            <div class="drawer-body">
-              <div class="detail-meta-grid">
-                <div class="meta-item"><span class="meta-label">系統</span><span class="meta-value" id="detailSystem">—</span></div>
-                <div class="meta-item"><span class="meta-label">成員</span><span class="meta-value" id="detailMember">—</span></div>
-                <div class="meta-item"><span class="meta-label">時間（台灣）</span><span class="meta-value" id="detailTimeTw">—</span></div>
-                <div class="meta-item"><span class="meta-label">時間（UTC）</span><span class="meta-value" id="detailTimeUtc">—</span></div>
-                <div class="meta-item"><span class="meta-label">位置</span><span class="meta-value" id="detailLocation">—</span></div>
-                <div class="meta-item"><span class="meta-label">中心氣壓</span><span class="meta-value" id="detailPressure">—</span></div>
-              </div>
-              <div class="detail-metrics">
-                <div class="metric-card">
-                  <span class="metric-label">目前風速</span>
+            <div class="detail-hero">
+              <div class="detail-hero-left">
+                <div class="detail-badges">
+                  <span class="badge system" id="detailSystem">—</span>
+                  <span class="badge member" id="detailMember">—</span>
+                </div>
+                <div class="detail-wind">
                   <span class="metric-value" id="detailWindPrimary">—</span>
                   <span class="metric-sub" id="detailWind">—</span>
                 </div>
-                <div class="metric-card">
-                  <span class="metric-label">分級（kt）</span>
-                  <span class="metric-value" id="detailKtClass">—</span>
-                </div>
-                <div class="metric-card">
-                  <span class="metric-label">分級（m/s）</span>
-                  <span class="metric-value" id="detailMsClass">—</span>
-                </div>
               </div>
-              <div class="detail-timeline">
-                <div class="timeline-card" id="detailPrevCard">
-                  <div class="timeline-title">上一時刻</div>
-                  <div class="timeline-time" id="detailPrevTime">—</div>
-                  <div class="timeline-wind" id="detailPrevWind">—</div>
-                </div>
-                <div class="timeline-card current">
-                  <div class="timeline-title">目前節點</div>
-                  <div class="timeline-time" id="detailCurrentTime">—</div>
-                  <div class="timeline-wind" id="detailCurrentWind">—</div>
-                  <div class="timeline-trend" id="detailTrend">—</div>
-                </div>
-                <div class="timeline-card" id="detailNextCard">
-                  <div class="timeline-title">下一時刻</div>
-                  <div class="timeline-time" id="detailNextTime">—</div>
-                  <div class="timeline-wind" id="detailNextWind">—</div>
-                </div>
+              <div class="detail-grades">
+                <span class="grade" id="detailKtClass">—</span>
+                <span class="grade alt" id="detailMsClass">—</span>
               </div>
-              <div class="drawer-footer" id="detailFooter">選擇節點後顯示更多提示與建議操作。</div>
             </div>
+            <div class="detail-meta-grid">
+              <div class="meta-item"><span class="meta-label">時間（台灣）</span><span class="meta-value" id="detailTimeTw">—</span></div>
+              <div class="meta-item"><span class="meta-label">時間（UTC）</span><span class="meta-value" id="detailTimeUtc">—</span></div>
+              <div class="meta-item"><span class="meta-label">位置</span><span class="meta-value" id="detailLocation">—</span></div>
+              <div class="meta-item"><span class="meta-label">中心氣壓</span><span class="meta-value" id="detailPressure">—</span></div>
+            </div>
+            <div class="detail-timeline">
+              <div class="timeline-card" id="detailPrevCard">
+                <div class="timeline-title">上一時刻</div>
+                <div class="timeline-time" id="detailPrevTime">—</div>
+                <div class="timeline-wind" id="detailPrevWind">—</div>
+              </div>
+              <div class="timeline-card current">
+                <div class="timeline-title">目前節點</div>
+                <div class="timeline-time" id="detailCurrentTime">—</div>
+                <div class="timeline-wind" id="detailCurrentWind">—</div>
+                <div class="timeline-trend" id="detailTrend">—</div>
+              </div>
+              <div class="timeline-card" id="detailNextCard">
+                <div class="timeline-title">下一時刻</div>
+                <div class="timeline-time" id="detailNextTime">—</div>
+                <div class="timeline-wind" id="detailNextWind">—</div>
+              </div>
+            </div>
+            <div class="detail-footer" id="detailFooter">選擇節點後顯示更多提示與建議操作。</div>
           </aside>
+        </div>
+        <div class="analysis-grid">
+          <section class="analysis-card time-card" aria-labelledby="time-card-title">
+            <header class="analysis-header">
+              <div>
+                <h2 id="time-card-title">時間 × 強度圖</h2>
+                <p class="analysis-sub">比較決定性與系集變化，詳細數值顯示於下方資訊列。</p>
+              </div>
+              <div class="chip-row dense">
+                <select id="tsSystemSel"></select>
+                <span class="chip" id="tsModeDet" data-active="true">決定性</span>
+                <span class="chip" id="tsModeEns">所有系集</span>
+              </div>
+            </header>
+            <div id="tsWrap"><canvas id="tsChart" tabindex="0" aria-describedby="tsInspector"></canvas></div>
+            <div class="ts-inspector" id="tsInspector">
+              <div class="ts-inspector-main">
+                <span class="ts-time" id="tsInfoTime">尚無資料</span>
+                <span class="ts-value" id="tsInfoValue">—</span>
+              </div>
+              <div class="ts-inspector-meta">
+                <span class="ts-wind" id="tsInfoWind">—</span>
+                <span class="ts-grade" id="tsInfoClass">—</span>
+              </div>
+            </div>
+          </section>
         </div>
       </section>
     </div>


### PR DESCRIPTION
## Summary
- add a theme toggle and collapsible sidebar panels
- redesign the explorer workspace with a dedicated detail panel alongside the map
- move the time × intensity chart into the workspace and surface a persistent inspector for node data

## Testing
- python3 -m http.server 8000 (manual)


------
https://chatgpt.com/codex/tasks/task_e_68dfbd56ce488330a598d1d953dd73db